### PR TITLE
Feature/aldo bats test cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.venv
+tests/test_helper/*

--- a/tests/retries.bats
+++ b/tests/retries.bats
@@ -1,0 +1,21 @@
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+setup() {
+    # obtener el directorio que contiene este archivo
+    # usa $BATS_TEST_FILENAME en lugar de ${BASH_SOURCE[0]} o $0,
+    # ya que estas últimas apuntan a la ubicación del bats ejecutable
+    # o al archivo preprocesado respectivamente
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+
+    # make executables in src/ visible to PATH
+    PATH="$DIR/../src:$PATH"
+
+    TEST_URL="http://127.0.0.1:9999/unreachable"
+}
+
+@test "cliente reintenta en caso de timeout" {
+    run cliente.sh "$TEST_URL"
+    assert_failure
+    assert_output --partial 'Intento 3'
+}

--- a/tests/retries.bats
+++ b/tests/retries.bats
@@ -8,14 +8,14 @@ setup() {
     # o al archivo preprocesado respectivamente
     DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
 
-    # make executables in src/ visible to PATH
+    # hacer los ejecutables en src/ visibles a la variable de entorno PATH
     PATH="$DIR/../src:$PATH"
 
     TEST_URL="http://127.0.0.1:9999/unreachable"
 }
 
 @test "cliente reintenta en caso de timeout" {
-    run cliente.sh "$TEST_URL"
+    run cliente.sh GET "$TEST_URL"
     assert_failure
     assert_output --partial 'Intento 3'
 }

--- a/tests/retries.bats
+++ b/tests/retries.bats
@@ -1,6 +1,10 @@
 load 'test_helper/bats-support/load'
 load 'test_helper/bats-assert/load'
 
+setup_file() {
+    mkdir -p out
+}
+
 setup() {
     # obtener el directorio que contiene este archivo
     # usa $BATS_TEST_FILENAME en lugar de ${BASH_SOURCE[0]} o $0,
@@ -12,6 +16,15 @@ setup() {
     PATH="$DIR/../src:$PATH"
 
     TEST_URL="http://127.0.0.1:9999/unreachable"
+}
+
+teardown() {
+    # Guardar salida y estado desde de cada prueba
+
+    # Quitar secuencias ANSI y guardar salida
+    echo "$output" | sed -r 's/\x1B\[[0-9;]*[A-Za-z]//g' > "out/${BATS_TEST_NAME}.out"
+    # Guardar estado 
+    echo "$status" > "out/${BATS_TEST_NAME}.status"
 }
 
 @test "cliente reintenta en caso de timeout" {


### PR DESCRIPTION
## ¿Qué?

- Se agregó la prueba mínima en tests/retries.bats: "cliente reintenta en caso de timeout" usando RGR.
- Se integró el target deps en el Makefile para instalar dependencias de Bats (ej. bats-support, bats-assert) vía git clone en tests/test_helper/.
- Se añadió setup_file() para crear el directorio out/ si no existe y teardown() para guardar reportes de salida y estado.
- Se ignoró la ruta tests/test_helper en git para evitar agregar repos externos.

## ¿Por qué?

- Para iniciar pruebas automáticas sobre el comportamiento de reintentos del cliente CLI, aunque todavía no exista el script.
- Para simplificar la gestión de dependencias de testing y permitir su extensión futura solo corriendo make deps.
- Para mantener limpio el repo y aislar las dependencias externas.

## ¿Cómo?

- Nueva prueba en Bats que falla correctamente al no existir aún cliente.sh.
- Declaración de dependencias en el Makefile como pares clave=valor, clonadas automáticamente con make deps.
- Hooks setup_file/teardown agregados para preparar entorno y generar reportes.
- .gitignore actualizado para excluir tests/test_helper/.

Close #3