### PR TITLE
Feature/aldo bats test cli docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,25 @@ Ejecute desde la raíz del proyecto:
 make prepare
 ```
 Luego, editar el .env según sus necesidades.
+
+## Ejecución de pruebas
+
+### Ejecución automatizada de pruebas
+
+Ejecuta desde la raíz del proyecto:
+
+```bash
+make test
+```
+
+### Extensión de las dependencias de las pruebas
+
+Para añadir más dependencias de Bats, como bats-file, agrega a la variable BATS_MODULES el nombre de la nueva dependencia, signo igual (=) y url del repo con .git al final:
+
+```Makefile
+BATS_MODULES := \
+	bats-support=https://github.com/bats-core/bats-support.git \
+	bats-assert=https://github.com/bats-core/bats-assert.git \
+    nueva-dependencia=repo-url
+```
+


### PR DESCRIPTION
## ¿Qué?

- Se agrega documentación en bitacora-sprint-1.md y README.md sobre la primera prueba con Bats y la integración inicial en el flujo del proyecto.

## ¿Por qué?

- Mantener un registro claro del avance del sprint.
- Facilitar a otros contribuidores entender cómo ejecutar y extender las pruebas Bats.
- Evitar que el conocimiento quede disperso y sin versionar.

## ¿Cómo?

- En bitacora-sprint-1.md se documenta el paso a paso de la primera prueba Bats, su ejecución manual, integración con Makefile, setup/teardown y extensión de dependencias.
- En README.md se añade la instrucción básica de cómo correr las pruebas con make test.