### PR TITLE
Feature/aldo ampliar bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ server: ## Levantar servidor Flask en background
 	@echo -e "\n[+] Levantando servidor Flask..."
 	@$(PY) src/server.py
 
-test: deps ## Ejecutar tests
+test: deps prepare ## Ejecutar tests
 	@echo -e "\n[+] Ejecutando pruebas..."
 	@echo "Levantando servidor..."
 	@$(PY) src/server.py & SERVER_PID=$$!; \

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ chmod +x src/cliente.sh
 ```
 
 ### Opción 2: Configuración automática con Makefile
+
 Ejecute desde la raíz del proyecto:
 ```bash
 make run
@@ -81,6 +82,8 @@ Se ejecuta las peticiones `GET`, `POST`, `PUT`, en ese orden. Y con **URLs** y *
 
 ## Ejecución de pruebas
 
+Las pruebas están implementadas con Bats y cubren la interacción completa entre el cliente (cliente.sh) y el servidor (server.py), actuando como pruebas end-to-end (E2E). Cada conjunto de pruebas valida comportamientos específicos de los endpoints (GET, POST, PUT) y escenarios de reintento ante fallas de red. Cada archivo de prueba `tests/nombre_prueba.bats` genera su salida limpia en out/<nombre_prueba>.out y el código de estado en out/<nombre_prueba>.status.
+
 ### Ejecución automatizada de pruebas
 
 Ejecuta desde la raíz del proyecto:
@@ -88,6 +91,12 @@ Ejecuta desde la raíz del proyecto:
 ```bash
 make test
 ```
+
+Este comando:
+- Crea el entorno virtual `.venv/` (si no existe) con dependencias instaladas desde `requirements.txt` para poder levantar el servidor.
+- Levanta temporalmente el servidor (server.py) en segundo plano.
+- Ejecuta todos los archivos .bats dentro de tests/ contra el cliente (cliente.sh).
+- Detiene el servidor al finalizar las pruebas.
 
 ### Extensión de las dependencias de las pruebas
 

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -1,6 +1,3 @@
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
-
 setup_file() {
     mkdir -p out
 }
@@ -15,7 +12,8 @@ setup() {
     # hacer los ejecutables en src/ visibles a la variable de entorno PATH
     PATH="$DIR/../src:$PATH"
 
-    TEST_URL="http://127.0.0.1:9999/unreachable"
+    TEST_URL="http://127.0.0.1"
+    PORT=8080
 }
 
 teardown() {
@@ -25,10 +23,4 @@ teardown() {
     echo "$output" | sed -r 's/\x1B\[[0-9;]*[A-Za-z]//g' > "out/${BATS_TEST_NAME}.out"
     # Guardar estado 
     echo "$status" > "out/${BATS_TEST_NAME}.status"
-}
-
-@test "cliente reintenta en caso de timeout" {
-    run cliente.sh GET "$TEST_URL"
-    assert_failure
-    assert_output --partial 'Intento 3'
 }

--- a/tests/test_get.bats
+++ b/tests/test_get.bats
@@ -1,0 +1,21 @@
+load 'common.bash'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+# Casos positivos (+)
+
+@test "GET courses retorna 200 y lista de cursos" {
+  run cliente.sh GET "$TEST_URL:$PORT/courses"
+  assert_success
+  assert_output --partial "GET exitoso"
+  assert_output --partial "Status: 200"
+}
+
+
+# Casos negativos (-)
+
+@test "cliente falla con URL inválida" {
+    run cliente.sh GET "ftp://bad-url"
+    assert_failure
+    assert_output --partial "Error: URL debe comenzar con http:// o https://"
+}

--- a/tests/test_post.bats
+++ b/tests/test_post.bats
@@ -1,0 +1,43 @@
+load 'common.bash'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+# Casos positivos (+)
+
+@test "cliente POST responde exitosamente con body por defecto" {
+    run cliente.sh POST "$TEST_URL:$PORT/create"
+    assert_success
+    assert_output --partial '[✓]'
+}
+
+@test "POST /create crea un curso nuevo con 201" {
+  body='{"Nombre":"Inteligencia Artificial","Codigo":"CC500"}'
+  run cliente.sh POST "$TEST_URL:$PORT/create" "$body"
+  assert_success
+  assert_output --partial "POST exitoso"
+  assert_output --partial "Status: 201"
+}
+
+@test "cliente POST /create respeta idempotency key custom" {
+    body='{"Nombre":"Probabilidades","Codigo":"PRB456"}'
+    run cliente.sh POST "$TEST_URL:$PORT/create" "$body" --idempotencykey "customkey123"
+    assert_success
+    assert_output --partial "Status: 201"
+}
+
+
+# Casos negativos (-)
+
+@test "cliente POST falla si falta valor para --idempotencykey" {
+    run cliente.sh POST "$TEST_URL:$PORT/resource" --idempotencykey
+    assert_failure
+    assert_output --partial "Error: --idempotencykey requiere un valor"
+}
+
+@test "POST /create con mismo Codigo retorna 409 (idempotencia)" {
+  body='{"Nombre":"Inteligencia Artificial","Codigo":"CC500"}'
+  run cliente.sh POST "$TEST_URL:$PORT/create" "$body" --idempotencykey "fixed-key-123"
+  run cliente.sh POST "$TEST_URL:$PORT/create" "$body" --idempotencykey "fixed-key-123"
+  assert_failure
+  assert_output --partial "Status: 409"
+}

--- a/tests/test_put.bats
+++ b/tests/test_put.bats
@@ -1,0 +1,22 @@
+load 'common.bash'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+# Casos positivos (-)
+
+@test "PUT /update actualiza un curso existente" {
+    cliente.sh POST "$TEST_URL:$PORT/create" '{"Nombre":"Nuevo","Codigo":"X1"}'
+    run cliente.sh PUT "$TEST_URL:$PORT/update" '{"Nombre":"Actualizado","Codigo":"X1"}'
+    assert_success
+    assert_output --partial "PUT exitoso"
+    assert_output --partial "Status: 200"
+}
+
+
+# Casos negativos (-)
+
+@test "cliente PUT /update reintenta si el servidor no responde" {
+    run cliente.sh PUT "$TEST_URL:9999/update" '{"Nombre":"Dummy","Codigo":"X999"}'
+    assert_failure
+    assert_output --partial "Intento 3"
+}

--- a/tests/test_retries.bats
+++ b/tests/test_retries.bats
@@ -8,3 +8,9 @@ load 'test_helper/bats-assert/load'
     assert_output --partial 'Intento 3'
     refute_output --partial 'Intento 4'
 }
+
+@test "cliente PUT /update reintenta si el servidor no responde" {
+    run cliente.sh PUT "$TEST_URL:9999/update" '{"Nombre":"Dummy","Codigo":"X999"}'
+    assert_failure
+    assert_output --partial "Intento 3"
+}

--- a/tests/test_retries.bats
+++ b/tests/test_retries.bats
@@ -1,0 +1,10 @@
+load 'common.bash'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+@test "cliente reintenta en caso de timeout" {
+    run cliente.sh GET "$TEST_URL:9999/unreachable"
+    assert_failure
+    assert_output --partial 'Intento 3'
+    refute_output --partial 'Intento 4'
+}


### PR DESCRIPTION
## ¿Qué?

- Refactoriza la estructura de pruebas Bats en múltiples archivos (test_get.bats, test_post.bats, test_put.bats, test_retries.bats).
- Extrae los hooks setup_file, setup y teardown a un archivo común common.bash.
- Actualiza el Makefile para automatizar la ejecución end-to-end (make test).
- Añade la creación automática de entorno virtual y la instalación de dependencias (make prepare).

## ¿Por qué?

- Facilita la extensión de pruebas sin duplicar configuración.
- Permite ejecutar los tests de cliente y servidor de forma integrada.
- Mejora la reproducibilidad del entorno de desarrollo.
- Simplifica la ejecución con un único comando (make test).

## ¿Cómo?

- Centralización de hooks en tests/common.bash para compartir configuración y registro de resultados.
- Reorganización modular de pruebas según método HTTP y tipo de caso (positivo/negativo).
- En el Makefile, el target test levanta el servidor, corre los tests y luego lo detiene.
- El target prepare crea .venv/ y ejecuta instalación desde requirements.txt.

Close #5 